### PR TITLE
Add support for assertion extensions

### DIFF
--- a/lib/saml_idp/assertion_builder.rb
+++ b/lib/saml_idp/assertion_builder.rb
@@ -69,8 +69,11 @@ module SamlIdp
               confirmation_hash[:InResponseTo] = saml_request_id unless saml_request_id.nil?
               confirmation_hash[:NotOnOrAfter] = not_on_or_after_subject
               confirmation_hash[:Recipient] = saml_acs_url
-
-              confirmation.SubjectConfirmationData "", confirmation_hash
+              if assertion_extension.present? && assertion_extension.extension_point == AssertionExtension::SUBJECT_CONFIRMATION_DATA_EXTENSION_POINT
+                confirmation.SubjectConfirmationData assertion_extension.build
+              else
+                confirmation.SubjectConfirmationData "", confirmation_hash
+              end
             end
           end
           assertion.Conditions NotBefore: not_before, NotOnOrAfter: not_on_or_after_condition do |conditions|
@@ -88,6 +91,9 @@ module SamlIdp
           assertion.AuthnStatement authn_statement_props do |statement|
             statement.AuthnContext do |context|
               context.AuthnContextClassRef authn_context_classref
+              if assertion_extension.present? && assertion_extension.extension_point == AssertionExtension::AUTHN_CONTEXT_DECL_EXTENSION_POINT
+                context.AuthnContextDecl assertion_extension.build
+              end
             end
           end
           if asserted_attributes

--- a/lib/saml_idp/assertion_builder.rb
+++ b/lib/saml_idp/assertion_builder.rb
@@ -70,7 +70,7 @@ module SamlIdp
               confirmation_hash[:NotOnOrAfter] = not_on_or_after_subject
               confirmation_hash[:Recipient] = saml_acs_url
               if assertion_extension.present? && assertion_extension.extension_point == AssertionExtension::SUBJECT_CONFIRMATION_DATA_EXTENSION_POINT
-                assertion_extension.extend confirmation
+                assertion_extension.build confirmation
               else
                 confirmation.SubjectConfirmationData "", confirmation_hash
               end
@@ -92,7 +92,7 @@ module SamlIdp
             statement.AuthnContext do |context|
               context.AuthnContextClassRef authn_context_classref
               if assertion_extension.present? && assertion_extension.extension_point == AssertionExtension::AUTHN_CONTEXT_DECL_EXTENSION_POINT
-                assertion_extension.extend context
+                assertion_extension.build context
               end
             end
           end

--- a/lib/saml_idp/assertion_builder.rb
+++ b/lib/saml_idp/assertion_builder.rb
@@ -51,7 +51,7 @@ module SamlIdp
       self.session_expiry = session_expiry.nil? ? config.session_expiry : session_expiry
       self.name_id_formats_opts = name_id_formats_opts
       self.asserted_attributes_opts = asserted_attributes_opts
-      self assertion_extension = assertion_extension
+      self.assertion_extension = assertion_extension
     end
 
     def fresh
@@ -70,7 +70,7 @@ module SamlIdp
               confirmation_hash[:NotOnOrAfter] = not_on_or_after_subject
               confirmation_hash[:Recipient] = saml_acs_url
               if assertion_extension.present? && assertion_extension.extension_point == AssertionExtension::SUBJECT_CONFIRMATION_DATA_EXTENSION_POINT
-                confirmation.SubjectConfirmationData assertion_extension.build
+                assertion_extension.extend confirmation
               else
                 confirmation.SubjectConfirmationData "", confirmation_hash
               end
@@ -92,7 +92,7 @@ module SamlIdp
             statement.AuthnContext do |context|
               context.AuthnContextClassRef authn_context_classref
               if assertion_extension.present? && assertion_extension.extension_point == AssertionExtension::AUTHN_CONTEXT_DECL_EXTENSION_POINT
-                context.AuthnContextDecl assertion_extension.build
+                assertion_extension.extend context
               end
             end
           end

--- a/lib/saml_idp/assertion_builder.rb
+++ b/lib/saml_idp/assertion_builder.rb
@@ -18,6 +18,7 @@ module SamlIdp
     attr_accessor :session_expiry
     attr_accessor :name_id_formats_opts
     attr_accessor :asserted_attributes_opts
+    attr_accessor :assertion_extension
 
     delegate :config, to: :SamlIdp
 
@@ -34,7 +35,8 @@ module SamlIdp
         encryption_opts=nil,
         session_expiry=nil,
         name_id_formats_opts = nil,
-        asserted_attributes_opts = nil
+        asserted_attributes_opts = nil,
+        assertion_extension = nil
     )
       self.reference_id = reference_id
       self.issuer_uri = issuer_uri
@@ -49,6 +51,7 @@ module SamlIdp
       self.session_expiry = session_expiry.nil? ? config.session_expiry : session_expiry
       self.name_id_formats_opts = name_id_formats_opts
       self.asserted_attributes_opts = asserted_attributes_opts
+      self assertion_extension = assertion_extension
     end
 
     def fresh

--- a/lib/saml_idp/assertion_extension.rb
+++ b/lib/saml_idp/assertion_extension.rb
@@ -1,0 +1,23 @@
+require "builder"
+module SamlIdp
+  class AssertionExtension
+    SUBJECT_CONFIRMATION_DATA_EXTENSION_POINT = "SubjectConfirmationData"
+    AUTHN_CONTEXT_DECL_EXTENSION_POINT = "AuthnContextDecl"
+    ATTRIBUTE_VALUE_EXTENSION_POINT = "AttributeValue"
+
+    attr_accessor :extension_point
+
+    def initialize(extension_point)
+      self.extension_point = extension_point
+    end
+
+    # this is an abstract base class.
+    def build
+      raise "#{self.class} must implement build method"
+    end
+
+    def raw
+      build
+    end
+  end
+end

--- a/lib/saml_idp/assertion_extension.rb
+++ b/lib/saml_idp/assertion_extension.rb
@@ -3,7 +3,6 @@ module SamlIdp
   class AssertionExtension
     SUBJECT_CONFIRMATION_DATA_EXTENSION_POINT = "SubjectConfirmationData"
     AUTHN_CONTEXT_DECL_EXTENSION_POINT = "AuthnContextDecl"
-    ATTRIBUTE_VALUE_EXTENSION_POINT = "AttributeValue"
 
     attr_accessor :extension_point
 

--- a/lib/saml_idp/assertion_extension.rb
+++ b/lib/saml_idp/assertion_extension.rb
@@ -1,4 +1,5 @@
 require "builder"
+
 module SamlIdp
   class AssertionExtension
     SUBJECT_CONFIRMATION_DATA_EXTENSION_POINT = "SubjectConfirmationData"
@@ -11,12 +12,8 @@ module SamlIdp
     end
 
     # this is an abstract base class.
-    def build
-      raise "#{self.class} must implement build method"
-    end
-
-    def raw
-      build
+    def extend(context)
+      raise "#{self.class} must implement extend method"
     end
   end
 end

--- a/lib/saml_idp/assertion_extension.rb
+++ b/lib/saml_idp/assertion_extension.rb
@@ -12,8 +12,8 @@ module SamlIdp
     end
 
     # this is an abstract base class.
-    def extend(context)
-      raise "#{self.class} must implement extend method"
+    def build(context)
+      raise "#{self.class} must implement build method"
     end
   end
 end

--- a/lib/saml_idp/assertion_extension.rb
+++ b/lib/saml_idp/assertion_extension.rb
@@ -11,7 +11,20 @@ module SamlIdp
       self.extension_point = extension_point
     end
 
-    # this is an abstract base class.
+    # This is an abstract base class, an example extension may look like this:
+    #
+    # context.AuthnContextDecl do |builder|
+    #   builder.AuthenticationContextDeclaration xmlns: "urn:my_org:saml:2.0:Device" do |context|
+    #     context.Extension do |ext|
+    #       ext.Device xmlns: "urn:my_org:saml:2.0:ZeroTrust", ID: "f659c992-2b3d-4e2d-a155-6d32161e6754" do |device|
+    #         device.Trust do |trust|
+    #           trust.Data Name: "Managed", Value: true
+    #           trust.Data Name: "Compliant", Value: true
+    #         end
+    #       end
+    #     end
+    #   end
+    # end
     def build(context)
       raise "#{self.class} must implement build method"
     end

--- a/lib/saml_idp/controller.rb
+++ b/lib/saml_idp/controller.rb
@@ -65,6 +65,7 @@ module SamlIdp
       asserted_attributes_opts = opts[:attributes] || nil
       signed_assertion_opts = opts[:signed_assertion] || true
       compress_opts = opts[:compress] || false
+      assertion_extension = opts[:assertion_extension] || nil
 
       SamlResponse.new(
         reference_id,
@@ -83,7 +84,8 @@ module SamlIdp
         asserted_attributes_opts,
         signed_assertion_opts,
         signed_message_opts,
-        compress_opts
+        compress_opts,
+        assertion_extension
       ).build
     end
 

--- a/lib/saml_idp/saml_response.rb
+++ b/lib/saml_idp/saml_response.rb
@@ -23,6 +23,7 @@ module SamlIdp
     attr_accessor :signed_message_opts
     attr_accessor :signed_assertion_opts
     attr_accessor :compression_opts
+    attr_accessor :assertion_extension
 
     def initialize(
       reference_id,
@@ -41,7 +42,8 @@ module SamlIdp
       asserted_attributes_opts = nil,
       signed_message_opts = false,
       signed_assertion_opts = true,
-      compression_opts = false
+      compression_opts = false,
+      assertion_extension = nil
     )
 
       self.reference_id = reference_id
@@ -65,6 +67,7 @@ module SamlIdp
       self.name_id_formats_opts = name_id_formats_opts
       self.asserted_attributes_opts = asserted_attributes_opts
       self.compression_opts = compression_opts
+      self.assertion_extension = assertion_extension
     end
 
     def build
@@ -110,7 +113,8 @@ module SamlIdp
                              encryption_opts,
                              session_expiry,
                              name_id_formats_opts,
-                             asserted_attributes_opts
+                             asserted_attributes_opts,
+                             assertion_extension
     end
     private :assertion_builder
   end


### PR DESCRIPTION
This adds very basic support for extensions for the SAML response assertions.

For reference the noted protocol extensions points from [Section 7.2.2 of the SAML 2.0 spec](https://docs.oasis-open.org/security/saml/v2.0/saml-core-2.0-os.pdf#page=75)

> **7.2.1 Assertion Extension Points**
> The following constructs in the assertion schema allow constructs from arbitrary namespaces within them:
> - `<SubjectConfirmationData>`: Uses **xs:anyType**, which allows any sub-elements and attributes.
> - `<AuthnContextDecl>`: Uses **xs:anyType**, which allows any sub-elements and attributes. <AttributeValue>: Uses xs:anyType, which allows any sub-elements and attributes.
> - `<Advice>` and **AdviceType**: In addition to SAML-native elements, allows elements from other namespaces with lax schema validation processing.

Extension points are provided for the `<SubjectConfirmationData>` and `<AuthnContextDecl>` nodes noted above.

The expectation is that the consumer provides an extension class inheriting from the `SamlIdp::AssertionExtension` base class that implements the required `#build(context)` method. The subclass' `#build` method will called and passed `context` which is the `Builder::XmlMarkup` node to be extended. You should extend this following **_Builders_** syntax.

**Example:**
```ruby
def build(context)
  context.AuthnContextDecl do |builder|
    builder.AuthenticationContextDeclaration xmlns: "urn:my_org:saml:2.0:Device" do |context|
      context.Extension do |ext|
        ext.Device xmlns: "urn:my_org:saml:2.0:ZeroTrust", ID: "f659c992-2b3d-4e2d-a155-6d32161e6754" do |device|
          device.Trust do |trust|
            trust.Data Name: "Managed", Value: true
            trust.Data Name: "Compliant", Value: true
          end
        end
      end
    end
  end
end
```