### PR TITLE
Adds support for looking up certificates with a Proc

### DIFF
--- a/lib/saml_idp/signature_builder.rb
+++ b/lib/saml_idp/signature_builder.rb
@@ -21,7 +21,8 @@ module SamlIdp
     end
 
     def x509_certificate
-      SamlIdp.config.x509_certificate
+      certificate = SamlIdp.config.x509_certificate.is_a?(Proc) ? SamlIdp.config.x509_certificate.call : SamlIdp.config.x509_certificate
+      certificate
       .to_s
       .gsub(/-----BEGIN CERTIFICATE-----/,"")
       .gsub(/-----END CERTIFICATE-----/,"")

--- a/lib/saml_idp/signed_info_builder.rb
+++ b/lib/saml_idp/signed_info_builder.rb
@@ -65,7 +65,7 @@ module SamlIdp
     private :clean_algorithm_name
 
     def secret_key
-      SamlIdp.config.secret_key
+      SamlIdp.config.secret_key.is_a?(Proc) ? SamlIdp.config.secret_key.call : SamlIdp.config.secret_key
     end
     private :secret_key
 


### PR DESCRIPTION
This is a very simple implementation for supporting multiple signing certificates using a proc in the Saml IdP configuration.

```ruby
SamlIdp.configure do |config|
  config.x509_certificate = -> { Auth::SigningCertificateFinder.call&.public_certificate }
  config.secret_key = -> { Auth::SigningCertificateFinder.call&.private_key }
end
```