### PR TITLE
Add SHA1 support to fingerprint generation and expand test coverage

### DIFF
--- a/lib/saml_idp/fingerprint.rb
+++ b/lib/saml_idp/fingerprint.rb
@@ -7,6 +7,8 @@ module SamlIdp
 
     def self.digest_sha_class(sha_size)
       case sha_size
+      when :sha1
+        Digest::SHA1
       when :sha256
         Digest::SHA256
       when :sha512

--- a/spec/lib/saml_idp/fingerprint_spec.rb
+++ b/spec/lib/saml_idp/fingerprint_spec.rb
@@ -4,10 +4,24 @@ module SamlIdp
   describe Fingerprint do
     describe "certificate_digest" do
       let(:cert) { sp_x509_cert }
-      let(:fingerprint) { "a2:cb:f6:6b:bc:2a:33:b9:4f:f3:c3:7e:26:a4:21:cd:41:83:ef:26:88:fa:ba:71:37:40:07:3e:d5:76:04:b7" }
 
-      it "returns the fingerprint string" do
-        expect(Fingerprint.certificate_digest(cert, :sha256)).to eq(fingerprint)
+      it "returns a SHA1 fingerprint" do
+        fingerprint = Fingerprint.certificate_digest(cert, :sha1)
+        expect(fingerprint).to match(/\A([0-9a-f]{2}:){19}[0-9a-f]{2}\z/)
+      end
+
+      it "returns a SHA256 fingerprint" do
+        expected = "a2:cb:f6:6b:bc:2a:33:b9:4f:f3:c3:7e:26:a4:21:cd:41:83:ef:26:88:fa:ba:71:37:40:07:3e:d5:76:04:b7"
+        expect(Fingerprint.certificate_digest(cert, :sha256)).to eq(expected)
+      end
+
+      it "returns a SHA512 fingerprint" do
+        fingerprint = Fingerprint.certificate_digest(cert, :sha512)
+        expect(fingerprint).to match(/\A([0-9a-f]{2}:){63}[0-9a-f]{2}\z/)
+      end
+
+      it "raises for unsupported algorithms" do
+        expect { Fingerprint.certificate_digest(cert, :md5) }.to raise_error(ArgumentError, /Unsupported sha size parameter/)
       end
     end
   end


### PR DESCRIPTION
`SignedDocument#validate` compares fingerprints using both the XML's digest algorithm and a hardcoded SHA1 fallback (`fingerprint_cert_sha1`), but `Fingerprint.certificate_digest` only supports SHA256/SHA512; making it impossible to generate a fingerprint that reliably matches the SHA1 fallback. 

This adds `:sha1` support so callers can generate fingerprints consistent with what `validate` actually compares against.
